### PR TITLE
Feature: Parsing unaries

### DIFF
--- a/RobotPlusPlus.Core.Tests/CompilerTests/SimpleUnaryTests.cs
+++ b/RobotPlusPlus.Core.Tests/CompilerTests/SimpleUnaryTests.cs
@@ -1,0 +1,211 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RobotPlusPlus.Core.Compiling;
+using RobotPlusPlus.Core.Exceptions;
+
+namespace RobotPlusPlus.Core.Tests.CompilerTests
+{
+	[TestClass]
+	public class SimpleUnaryTests
+	{
+		[TestMethod]
+		public void Compile_NumberNegative()
+		{
+			// Arrange
+			const string code = "x = -50";
+			const string expected = "♥x=-50";
+
+			// Act
+			string actual = Compiler.Compile(code);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void Compile_NumberNegativeNegative()
+		{
+			// Arrange
+			const string code = "x = - -50";
+			const string expected = "♥x=50";
+
+			// Act
+			string actual = Compiler.Compile(code);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void Compile_NumberPositive()
+		{
+			// Arrange
+			const string code = "x = +50";
+			const string expected = "♥x=50";
+
+			// Act
+			string actual = Compiler.Compile(code);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void Compile_ParentasesNegative()
+		{
+			// Arrange
+			const string code = "x = -(50 + 5)";
+			const string expected = "♥x=-(50+5)";
+
+			// Act
+			string actual = Compiler.Compile(code);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void Compile_CommandNegative()
+		{
+			// Arrange
+			const string code = "x = -directory.filescount('c:/')";
+			const string expected = "directory.filescount path ‴c:/‴ result ♥tmp\n" +
+			                        "♥x=-♥tmp";
+
+			// Act
+			string actual = Compiler.Compile(code);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void Parse_NegateNegateBoolean()
+		{
+			// Arrange
+			const string code = "x = !!true";
+			const string expected = "♥x=true";
+
+			// Act
+			string actual = Compiler.Compile(code);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(CompileUnassignedVariableException))]
+		public void Parse_PrefixUnassignedVariable()
+		{
+			// Arrange
+			const string code = "++x";
+
+			// Act
+			Compiler.Compile(code);
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(CompileUnassignedVariableException))]
+		public void Parse_PostfixUnassignedVariable()
+		{
+			// Arrange
+			const string code = "x++";
+
+			// Act
+			Compiler.Compile(code);
+		}
+
+		[TestMethod]
+		public void Parse_PrefixVariable()
+		{
+			// Arrange
+			const string code = "x = 0; ++x";
+			const string expected = "♥x=0\n" +
+			                        "♥x=♥x+1";
+
+			// Act
+			string actual = Compiler.Compile(code);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void Parse_PostfixVariable()
+		{
+			// Arrange
+			const string code = "x = 0; x++";
+			const string expected = "♥x=0\n" +
+			                        "♥x=♥x+1";
+
+			// Act
+			string actual = Compiler.Compile(code);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void Parse_PrefixExpressionVariable()
+		{
+			// Arrange
+			const string code = "x = 0; y = ++x";
+			const string expected = "♥x=0\n" +
+			                        "♥x=♥x+1\n" +
+									"♥y=♥x";
+
+			// Act
+			string actual = Compiler.Compile(code);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void Parse_PostfixExpressionVariable()
+		{
+			// Arrange
+			const string code = "x = 0; y = x++";
+			const string expected = "♥x=0\n" +
+			                        "♥y=♥x\n" +
+			                        "♥x=♥x+1";
+
+			// Act
+			string actual = Compiler.Compile(code);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void Parse_PrefixNegativeExpressionVariable()
+		{
+			// Arrange
+			const string code = "x = 0; y = -++x";
+			const string expected = "♥x=0\n" +
+			                        "♥x=♥x+1\n" +
+			                        "♥y=-♥x";
+
+			// Act
+			string actual = Compiler.Compile(code);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
+		}
+
+		[TestMethod]
+		public void Parse_PostfixNegativeExpressionVariable()
+		{
+			// Arrange
+			const string code = "x = 0; y = -x++";
+			const string expected = "♥x=0\n" +
+			                        "♥y=-♥x\n" +
+			                        "♥x=♥x+1";
+
+			// Act
+			string actual = Compiler.Compile(code);
+
+			// Assert
+			Assert.AreEqual(expected, actual);
+		}
+	}
+}

--- a/RobotPlusPlus.Core.Tests/ParserTests/SimpleUnaryTests.cs
+++ b/RobotPlusPlus.Core.Tests/ParserTests/SimpleUnaryTests.cs
@@ -23,7 +23,7 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 			Assert.AreEqual(1, result.Length);
 
 			Assert.That.TokenIsOperator(result[0], OperatorToken.Type.Unary, "-");
-			Assert.That.TokenIsLiteralInteger(result[0][1], 50);
+			Assert.That.TokenIsLiteralInteger(result[0][0], 50);
 		}
 
 		[TestMethod]
@@ -40,8 +40,8 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 			Assert.AreEqual(1, result.Length);
 
 			Assert.That.TokenIsOperator(result[0], OperatorToken.Type.Unary, "-");
-			Assert.That.TokenIsOperator(result[0][1], OperatorToken.Type.Unary, "-");
-			Assert.That.TokenIsLiteralInteger(result[0][1][1], 50);
+			Assert.That.TokenIsOperator(result[0][0], OperatorToken.Type.Unary, "-");
+			Assert.That.TokenIsLiteralInteger(result[0][0][0], 50);
 		}
 
 		[TestMethod]
@@ -58,7 +58,7 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 			Assert.AreEqual(1, result.Length);
 
 			Assert.That.TokenIsOperator(result[0], OperatorToken.Type.Unary, "+");
-			Assert.That.TokenIsLiteralInteger(result[0][1], 50);
+			Assert.That.TokenIsLiteralInteger(result[0][0], 50);
 		}
 
 		[TestMethod]
@@ -76,7 +76,7 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 
 			Assert.That.TokenIsOperator(result[0], OperatorToken.Type.Unary, "-");
 
-			Token par = result[0][1];
+			Token par = result[0][0];
 			Assert.That.TokenIsParentases(par, '(', 1);
 			Token add = par[0];
 			Assert.That.TokenIsLiteralInteger(add[0], 50);
@@ -101,7 +101,7 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 
 			Token unary = add[1];
 			Assert.That.TokenIsOperator(unary, OperatorToken.Type.Unary, "-");
-			Assert.That.TokenIsLiteralInteger(unary[1], 5);
+			Assert.That.TokenIsLiteralInteger(unary[0], 5);
 		}
 
 		[TestMethod]
@@ -122,10 +122,10 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 
 			Token chain = add[1];
 			Assert.That.TokenIsOperator(chain, OperatorToken.Type.Unary, "-");
-			Assert.That.TokenIsOperator(chain[1], OperatorToken.Type.Unary, "-");
-			Assert.That.TokenIsOperator(chain[1][1], OperatorToken.Type.Unary, "-");
+			Assert.That.TokenIsOperator(chain[0], OperatorToken.Type.Unary, "-");
+			Assert.That.TokenIsOperator(chain[0][0], OperatorToken.Type.Unary, "-");
 
-			Assert.That.TokenIsLiteralInteger(chain[1][1][1], 5);
+			Assert.That.TokenIsLiteralInteger(chain[0][0][0], 5);
 		}
 
 		[TestMethod]
@@ -143,7 +143,7 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 
 			Token unary = result[0];
 			Assert.That.TokenIsOperator(unary, OperatorToken.Type.Unary, "!");
-			Assert.That.TokenIsLiteralKeyword(unary[1], true);
+			Assert.That.TokenIsLiteralKeyword(unary[0], true);
 		}
 
 		[TestMethod]
@@ -161,9 +161,9 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 
 			Token unary1 = result[0];
 			Assert.That.TokenIsOperator(unary1, OperatorToken.Type.Unary, "!");
-			Token unary2 = unary1[1];
+			Token unary2 = unary1[0];
 			Assert.That.TokenIsOperator(unary2, OperatorToken.Type.Unary, "!");
-			Assert.That.TokenIsLiteralKeyword(unary2[1], true);
+			Assert.That.TokenIsLiteralKeyword(unary2[0], true);
 		}
 
 		[TestMethod]
@@ -215,7 +215,7 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 
 			Token exp = result[0];
 			Assert.That.TokenIsOperator(exp, OperatorToken.Type.PreExpression, "++");
-			Assert.That.TokenIsOfType<IdentifierToken>(exp[1], "x");
+			Assert.That.TokenIsOfType<IdentifierToken>(exp[0], "x");
 		}
 
 		[TestMethod]
@@ -251,7 +251,7 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 
 			Token unary = result[0];
 			Assert.That.TokenIsOperator(unary, OperatorToken.Type.Unary, "-");
-			Token exp = unary[1];
+			Token exp = unary[0];
 			Assert.That.TokenIsOperator(exp, OperatorToken.Type.PostExpression, "++");
 			Assert.That.TokenIsOfType<IdentifierToken>(exp[0], "x");
 		}
@@ -271,9 +271,9 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 
 			Token unary = result[0];
 			Assert.That.TokenIsOperator(unary, OperatorToken.Type.Unary, "-");
-			Token exp = unary[1];
+			Token exp = unary[0];
 			Assert.That.TokenIsOperator(exp, OperatorToken.Type.PreExpression, "++");
-			Assert.That.TokenIsOfType<IdentifierToken>(exp[1], "x");
+			Assert.That.TokenIsOfType<IdentifierToken>(exp[0], "x");
 		}
 
 		[TestMethod]

--- a/RobotPlusPlus.Core.Tests/ParserTests/SimpleUnaryTests.cs
+++ b/RobotPlusPlus.Core.Tests/ParserTests/SimpleUnaryTests.cs
@@ -1,0 +1,180 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RobotPlusPlus.Core.Parsing;
+using RobotPlusPlus.Core.Tokenizing;
+using RobotPlusPlus.Core.Tokenizing.Tokens;
+
+namespace RobotPlusPlus.Core.Tests.ParserTests
+{
+	[TestClass]
+	public class SimpleUnaryTests
+	{
+		[TestMethod]
+		public void Parse_NumberNegative()
+		{
+			// Arrange
+			const string code = "-50";
+
+			// Act
+			Token[] result = Parser.Parse(Tokenizer.Tokenize(code));
+
+			// Assert
+			CollectionAssert.That.TokensAreParsed(result);
+			Assert.AreEqual(1, result.Length);
+
+			Assert.That.TokenIsOperator(result[0], OperatorToken.Type.Unary, "-");
+			Assert.That.TokenIsLiteralInteger(result[0][1], 50);
+		}
+
+		[TestMethod]
+		public void Parse_NumberNegativeNegative()
+		{
+			// Arrange
+			const string code = "- -50";
+
+			// Act
+			Token[] result = Parser.Parse(Tokenizer.Tokenize(code));
+
+			// Assert
+			CollectionAssert.That.TokensAreParsed(result);
+			Assert.AreEqual(1, result.Length);
+
+			Assert.That.TokenIsOperator(result[0], OperatorToken.Type.Unary, "-");
+			Assert.That.TokenIsOperator(result[0][0], OperatorToken.Type.Unary, "-");
+			Assert.That.TokenIsLiteralInteger(result[0][0][1], 50);
+		}
+
+		[TestMethod]
+		public void Parse_NumberPositive()
+		{
+			// Arrange
+			const string code = "+50";
+
+			// Act
+			Token[] result = Parser.Parse(Tokenizer.Tokenize(code));
+
+			// Assert
+			CollectionAssert.That.TokensAreParsed(result);
+			Assert.AreEqual(1, result.Length);
+
+			Assert.That.TokenIsOperator(result[0], OperatorToken.Type.Unary, "+");
+			Assert.That.TokenIsLiteralInteger(result[0][1], 50);
+		}
+
+		[TestMethod]
+		public void Parse_ParentasesNegative()
+		{
+			// Arrange
+			const string code = "-(50 + 5)";
+
+			// Act
+			Token[] result = Parser.Parse(Tokenizer.Tokenize(code));
+
+			// Assert
+			CollectionAssert.That.TokensAreParsed(result);
+			Assert.AreEqual(1, result.Length);
+
+			Assert.That.TokenIsOperator(result[0], OperatorToken.Type.Unary, "-");
+
+			Token par = result[0][1];
+			Assert.That.TokenIsParentases(par, '(', 1);
+			Token add = par[0];
+			Assert.That.TokenIsLiteralInteger(add[0], 50);
+			Assert.That.TokenIsLiteralInteger(add[1], 5);
+		}
+
+		[TestMethod]
+		public void Parse_InExpression()
+		{
+			// Arrange
+			const string code = "50 + -5";
+
+			// Act
+			Token[] result = Parser.Parse(Tokenizer.Tokenize(code));
+
+			// Assert
+			CollectionAssert.That.TokensAreParsed(result);
+			Assert.AreEqual(1, result.Length);
+
+			Token add = result[0];
+			Assert.That.TokenIsLiteralInteger(add[0], 50);
+
+			Token unary = add[1];
+			Assert.That.TokenIsOperator(unary, OperatorToken.Type.Unary, "-");
+			Assert.That.TokenIsLiteralInteger(unary[1], 5);
+		}
+
+		[TestMethod]
+		public void Parse_NegateBoolean()
+		{
+			// Arrange
+			const string code = "!true";
+
+			// Act
+			Token[] result = Parser.Parse(Tokenizer.Tokenize(code));
+
+			// Assert
+			CollectionAssert.That.TokensAreParsed(result);
+			Assert.AreEqual(1, result.Length);
+
+			Token unary = result[0];
+			Assert.That.TokenIsOperator(unary, OperatorToken.Type.Unary, "!");
+			Assert.That.TokenIsLiteralKeyword(unary[1], true);
+		}
+
+		[TestMethod]
+		public void Parse_NegateNegateBoolean()
+		{
+			// Arrange
+			const string code = "!!true";
+
+			// Act
+			Token[] result = Parser.Parse(Tokenizer.Tokenize(code));
+
+			// Assert
+			CollectionAssert.That.TokensAreParsed(result);
+			Assert.AreEqual(1, result.Length);
+
+			Token unary1 = result[0];
+			Assert.That.TokenIsOperator(unary1, OperatorToken.Type.Unary, "!");
+			Token unary2 = unary1[1];
+			Assert.That.TokenIsOperator(unary2, OperatorToken.Type.Unary, "!");
+			Assert.That.TokenIsLiteralKeyword(unary2[1], true);
+		}
+
+		[TestMethod]
+		public void Parse_PrefixVariable()
+		{
+			// Arrange
+			const string code = "++x";
+
+			// Act
+			Token[] result = Parser.Parse(Tokenizer.Tokenize(code));
+
+			// Assert
+			CollectionAssert.That.TokensAreParsed(result);
+			Assert.AreEqual(1, result.Length);
+
+			Token exp = result[0];
+			Assert.That.TokenIsOperator(exp, OperatorToken.Type.Expression, "++");
+			Assert.That.TokenIsOfType<IdentifierToken>(exp[1], "x");
+		}
+
+		[TestMethod]
+		public void Parse_PostfixVariable()
+		{
+			// Arrange
+			const string code = "x++";
+
+			// Act
+			Token[] result = Parser.Parse(Tokenizer.Tokenize(code));
+
+			// Assert
+			CollectionAssert.That.TokensAreParsed(result);
+			Assert.AreEqual(1, result.Length);
+
+			Token exp = result[0];
+			Assert.That.TokenIsOperator(exp, OperatorToken.Type.Expression, "++");
+			Assert.That.TokenIsOfType<IdentifierToken>(exp[0], "x");
+		}
+	}
+}

--- a/RobotPlusPlus.Core.Tests/ParserTests/SimpleUnaryTests.cs
+++ b/RobotPlusPlus.Core.Tests/ParserTests/SimpleUnaryTests.cs
@@ -40,8 +40,8 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 			Assert.AreEqual(1, result.Length);
 
 			Assert.That.TokenIsOperator(result[0], OperatorToken.Type.Unary, "-");
-			Assert.That.TokenIsOperator(result[0][0], OperatorToken.Type.Unary, "-");
-			Assert.That.TokenIsLiteralInteger(result[0][0][1], 50);
+			Assert.That.TokenIsOperator(result[0][1], OperatorToken.Type.Unary, "-");
+			Assert.That.TokenIsLiteralInteger(result[0][1][1], 50);
 		}
 
 		[TestMethod]
@@ -105,6 +105,30 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 		}
 
 		[TestMethod]
+		public void Parse_InExpressionWithChain()
+		{
+			// Arrange
+			const string code = "50 + - - -5";
+
+			// Act
+			Token[] result = Parser.Parse(Tokenizer.Tokenize(code));
+
+			// Assert
+			CollectionAssert.That.TokensAreParsed(result);
+			Assert.AreEqual(1, result.Length);
+
+			Token add = result[0];
+			Assert.That.TokenIsLiteralInteger(add[0], 50);
+
+			Token chain = add[1];
+			Assert.That.TokenIsOperator(chain, OperatorToken.Type.Unary, "-");
+			Assert.That.TokenIsOperator(chain[1], OperatorToken.Type.Unary, "-");
+			Assert.That.TokenIsOperator(chain[1][1], OperatorToken.Type.Unary, "-");
+
+			Assert.That.TokenIsLiteralInteger(chain[1][1][1], 5);
+		}
+
+		[TestMethod]
 		public void Parse_NegateBoolean()
 		{
 			// Arrange
@@ -143,21 +167,15 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 		}
 
 		[TestMethod]
+		// Because of the tokenizer, this should compile to --(-x)
+		[ExpectedException(typeof(ParseUnexpectedTrailingTokenException))]
 		public void Parse_TrippleNegateVariable()
 		{
 			// Arrange
 			const string code = "---x";
 
 			// Act
-			Token[] result = Parser.Parse(Tokenizer.Tokenize(code));
-
-			// Assert
-			CollectionAssert.That.TokensAreParsed(result);
-			Assert.AreEqual(1, result.Length);
-
-			Token exp = result[0];
-			Assert.That.TokenIsOperator(exp, OperatorToken.Type.Expression, "++");
-			Assert.That.TokenIsOfType<IdentifierToken>(exp[1], "x");
+			Parser.Parse(Tokenizer.Tokenize(code));
 		}
 
 		[TestMethod]
@@ -196,7 +214,7 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 			Assert.AreEqual(1, result.Length);
 
 			Token exp = result[0];
-			Assert.That.TokenIsOperator(exp, OperatorToken.Type.Expression, "++");
+			Assert.That.TokenIsOperator(exp, OperatorToken.Type.PreExpression, "++");
 			Assert.That.TokenIsOfType<IdentifierToken>(exp[1], "x");
 		}
 
@@ -214,7 +232,7 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 			Assert.AreEqual(1, result.Length);
 
 			Token exp = result[0];
-			Assert.That.TokenIsOperator(exp, OperatorToken.Type.Expression, "++");
+			Assert.That.TokenIsOperator(exp, OperatorToken.Type.PostExpression, "++");
 			Assert.That.TokenIsOfType<IdentifierToken>(exp[0], "x");
 		}
 
@@ -234,7 +252,7 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 			Token unary = result[0];
 			Assert.That.TokenIsOperator(unary, OperatorToken.Type.Unary, "-");
 			Token exp = unary[1];
-			Assert.That.TokenIsOperator(exp, OperatorToken.Type.Expression, "++");
+			Assert.That.TokenIsOperator(exp, OperatorToken.Type.PostExpression, "++");
 			Assert.That.TokenIsOfType<IdentifierToken>(exp[0], "x");
 		}
 
@@ -254,7 +272,7 @@ namespace RobotPlusPlus.Core.Tests.ParserTests
 			Token unary = result[0];
 			Assert.That.TokenIsOperator(unary, OperatorToken.Type.Unary, "-");
 			Token exp = unary[1];
-			Assert.That.TokenIsOperator(exp, OperatorToken.Type.Expression, "++");
+			Assert.That.TokenIsOperator(exp, OperatorToken.Type.PreExpression, "++");
 			Assert.That.TokenIsOfType<IdentifierToken>(exp[1], "x");
 		}
 

--- a/RobotPlusPlus.Core.Tests/Utility.cs
+++ b/RobotPlusPlus.Core.Tests/Utility.cs
@@ -61,6 +61,15 @@ namespace RobotPlusPlus.Core.Tests
 		}
 
 		[AssertionMethod]
+		public static void TokenIsLiteralKeyword(this Assert assert,
+			[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] Token token, bool? value)
+		{
+			Assert.IsNotNull(token);
+			Assert.IsInstanceOfType(token, typeof(LiteralKeywordToken));
+			Assert.AreEqual(value, ((LiteralKeywordToken)token).Value);
+		}
+
+		[AssertionMethod]
 		public static void TokenIsParentases(this Assert assert,
 			[AssertionCondition(AssertionConditionType.IS_NOT_NULL)] Token token, char expectedOpeningChar)
 		{

--- a/RobotPlusPlus.Core/Compiling/CodeUnits/CodeUnit.cs
+++ b/RobotPlusPlus.Core/Compiling/CodeUnits/CodeUnit.cs
@@ -44,6 +44,11 @@ namespace RobotPlusPlus.Core.Compiling.CodeUnits
 
 					return new AssignmentUnit(op, parent);
 
+				case OperatorToken op when op.OperatorType == OperatorToken.Type.PreExpression
+					|| op.OperatorType == OperatorToken.Type.PostExpression:
+
+					return new AssignmentUnit(OperatorToken.ConvertPostPrefixToAssignment(op), parent);
+
 				case PunctuatorToken pun when pun.Character == ';':
 					return null;
 

--- a/RobotPlusPlus.Core/Compiling/CodeUnits/ExpressionUnit.cs
+++ b/RobotPlusPlus.Core/Compiling/CodeUnits/ExpressionUnit.cs
@@ -120,7 +120,7 @@ namespace RobotPlusPlus.Core.Compiling.CodeUnits
 					return $"{StringifyOperatorChildToken(op, op.LHS)}{op.SourceCode}{StringifyOperatorChildToken(op, op.RHS)}";
 
 				case OperatorToken op when op.OperatorType == OperatorToken.Type.Unary:
-					return $"{op.SourceCode}{StringifyToken(op.RHS)}";
+					return $"{op.SourceCode}{StringifyToken(op.UnaryValue)}";
 
 				default:
 					throw new CompileUnexpectedTokenException(token);

--- a/RobotPlusPlus.Core/Parsing/Parser.cs
+++ b/RobotPlusPlus.Core/Parsing/Parser.cs
@@ -30,12 +30,15 @@ namespace RobotPlusPlus.Core.Parsing
 		private static void ParseTokens(IList<Token> tokens, Predicate<Token> filter, bool reversed)
 		{
 			var parent = new IteratedList<Token>(tokens, reversed);
-			while (true)
+
+			bool any;
+			do
 			{
-				var any = false;
-				
+				any = false;
 				foreach (Token token in parent)
-				{	
+				{
+					if (token is null) continue;
+
 					ParseTokens(parent.Current, filter, parent.Reversed);
 
 					if (token.IsParsed) continue;
@@ -46,8 +49,7 @@ namespace RobotPlusPlus.Core.Parsing
 					any = true;
 				}
 
-				if (!any) return;
-			}
+			} while (any);
 		}
 
 		protected void ParseAllTokenTypes()

--- a/RobotPlusPlus.Core/Parsing/ParserExtensions.cs
+++ b/RobotPlusPlus.Core/Parsing/ParserExtensions.cs
@@ -18,10 +18,18 @@ namespace RobotPlusPlus.Core.Parsing
 			if (token == null) return false;
 			if (token.IsParsed) return false;
 
-			token.ParseToken(new IteratedList<Token>(parent, index, parent.Reversed));
-			token.IsParsed = true;
+			for (var i = 0; i < 42; i++)
+			{
+				token.ParseToken(new IteratedList<Token>(parent, index, parent.Reversed));
+				token.IsParsed = true;
 
-			return true;
+				token = index < parent.Count ? parent[index] : null;
+
+				if (token?.IsParsed != false)
+					return true;
+			}
+
+			throw new ParseTokenException($"Detected loop while parsing token <{token.SourceCode}>.", token);
 		}
 
 		public static bool ParseNextToken([NotNull] this IteratedList<Token> parent)

--- a/RobotPlusPlus.Core/Properties/AssemblyInfo.cs
+++ b/RobotPlusPlus.Core/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.5.18092.2373")]
-[assembly: AssemblyFileVersion("0.5.18092.2373")]
+[assembly: AssemblyVersion("0.5.18092.2393")]
+[assembly: AssemblyFileVersion("0.5.18092.2393")]
 
 [assembly: AssemblyTitle("Robot++ Compiler")]
 [assembly: AssemblyDescription("Compiler library for the Robot++ language.")]

--- a/RobotPlusPlus.Core/Properties/AssemblyInfo.cs
+++ b/RobotPlusPlus.Core/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.5.18092.2328")]
-[assembly: AssemblyFileVersion("0.5.18092.2328")]
+[assembly: AssemblyVersion("0.5.18092.2373")]
+[assembly: AssemblyFileVersion("0.5.18092.2373")]
 
 [assembly: AssemblyTitle("Robot++ Compiler")]
 [assembly: AssemblyDescription("Compiler library for the Robot++ language.")]

--- a/RobotPlusPlus.Core/Properties/AssemblyInfo.cs
+++ b/RobotPlusPlus.Core/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.5.18092.2393")]
-[assembly: AssemblyFileVersion("0.5.18092.2393")]
+[assembly: AssemblyVersion("0.5.18092.2441")]
+[assembly: AssemblyFileVersion("0.5.18092.2441")]
 
 [assembly: AssemblyTitle("Robot++ Compiler")]
 [assembly: AssemblyDescription("Compiler library for the Robot++ language.")]

--- a/RobotPlusPlus.Core/Properties/AssemblyInfo.cs
+++ b/RobotPlusPlus.Core/Properties/AssemblyInfo.cs
@@ -11,8 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("0.5.18092.1358")]
-[assembly: AssemblyFileVersion("0.5.18092.1358")]
+[assembly: AssemblyVersion("0.5.18092.2328")]
+[assembly: AssemblyFileVersion("0.5.18092.2328")]
 
 [assembly: AssemblyTitle("Robot++ Compiler")]
 [assembly: AssemblyDescription("Compiler library for the Robot++ language.")]

--- a/RobotPlusPlus.Core/Tokenizing/Tokens/OperatorToken.cs
+++ b/RobotPlusPlus.Core/Tokenizing/Tokens/OperatorToken.cs
@@ -27,6 +27,12 @@ namespace RobotPlusPlus.Core.Tokenizing.Tokens
 			set => this[1] = value;
 		}
 
+		public Token UnaryValue
+		{
+			get => this[0];
+			set => this[0] = value;
+		}
+
 		private OperatorToken(TokenSource source, Type operatorType) : base(source)
 		{
 			OperatorType = operatorType;
@@ -125,10 +131,10 @@ namespace RobotPlusPlus.Core.Tokenizing.Tokens
 					return true;
 
 				case OperatorToken op:
-					if (op.OperatorType == Type.Unary || op.OperatorType == Type.PreExpression)
-						return ExpressionHasValue(op.RHS) && op.LHS == null;
-					else if (op.OperatorType == Type.PostExpression)
-						return ExpressionHasValue(op.LHS) && op.RHS == null;
+					if (op.OperatorType == Type.Unary
+					    || op.OperatorType == Type.PreExpression
+					    || op.OperatorType == Type.PostExpression)
+						return ExpressionHasValue(op.UnaryValue);
 					else
 						return ExpressionHasValue(op.LHS) && ExpressionHasValue(op.RHS);
 
@@ -152,7 +158,7 @@ namespace RobotPlusPlus.Core.Tokenizing.Tokens
 				// Expression
 				case Type.PostExpression:
 					if (parent.Previous is IdentifierToken)
-						LHS = parent.PopPrevious();
+						UnaryValue = parent.PopPrevious();
 					else
 						parent.SwapCurrent(new OperatorToken(source, Type.PreExpression));
 					break;
@@ -161,7 +167,7 @@ namespace RobotPlusPlus.Core.Tokenizing.Tokens
 					if (!(parent.Next is IdentifierToken))
 						throw new ParseUnexpectedTrailingTokenException(this, parent.Next);
 
-					RHS = parent.PopNext();
+					UnaryValue = parent.PopNext();
 					break;
 
 				// Unary
@@ -174,7 +180,7 @@ namespace RobotPlusPlus.Core.Tokenizing.Tokens
 							parent.ParseNextToken();
 
 						if (ExpressionHasValue(parent.Next))
-							RHS = parent.PopNext();
+							UnaryValue = parent.PopNext();
 						else
 							throw new ParseUnexpectedTrailingTokenException(this, parent.Next);
 					}

--- a/RobotPlusPlus.Core/Tokenizing/Tokens/OperatorToken.cs
+++ b/RobotPlusPlus.Core/Tokenizing/Tokens/OperatorToken.cs
@@ -242,6 +242,30 @@ namespace RobotPlusPlus.Core.Tokenizing.Tokens
 			}
 		}
 
+		public static OperatorToken ConvertPostPrefixToAssignment(OperatorToken token)
+		{
+			// Fabricate tokens
+			TokenSource opSource = token.source;
+
+			opSource.code = opSource.code.Substring(0, 1);
+			var op = new OperatorToken(opSource);
+			opSource.code = "=";
+			var ass = new OperatorToken(opSource);
+			opSource.code = "1";
+			var one = new LiteralNumberToken(opSource);
+
+			Token id = token.UnaryValue as IdentifierToken
+				?? throw new ParseUnexpectedTokenException(token.UnaryValue);
+
+			// Fabricate & parse environment
+			Parser.Parse(new[]
+			{
+				id, ass, id, op, one
+			});
+
+			return ass;
+		}
+
 		public enum Type
 		{
 			///<summary>x++, x--</summary>

--- a/RobotPlusPlus.Core/Utility/ListUtilities.cs
+++ b/RobotPlusPlus.Core/Utility/ListUtilities.cs
@@ -111,14 +111,14 @@ namespace RobotPlusPlus.Core.Utility
 			[NotNull] Func<TSource, bool> predicate)
 			where TSource : IEnumerable<TSource>
 		{
-			return source.Any(item => predicate(item) || item.AnyRecursive(predicate));
+			return source.Any(item => predicate(item) || item?.AnyRecursive(predicate) == true);
 		}
 
 		public static bool AllRecursive<TSource>([NotNull] this IEnumerable<TSource> source,
 			[NotNull] Func<TSource, bool> predicate)
 			where TSource : IEnumerable<TSource>
 		{
-			return source.All(item => predicate(item) && item.AllRecursive(predicate));
+			return source.All(item => predicate(item) && item?.AllRecursive(predicate) == true);
 		}
 
 		public static bool AnyRecursive<TSource>([NotNull] this TSource source,
@@ -133,7 +133,7 @@ namespace RobotPlusPlus.Core.Utility
 			[NotNull] Func<TSource, bool> predicate, bool includeTop)
 			where TSource : IEnumerable<TSource>
 		{
-			if (includeTop) return predicate(source) && source.All(item => predicate(item) && item.AllRecursive(predicate));
+			if (includeTop) return predicate(source) && source.AllRecursive(predicate);
 			return source.AllRecursive(predicate);
 		}
 


### PR DESCRIPTION
# Feature: Parsing unary operations
I'm usually against negativity, so therefore I didn't want to add this feature. But with a hard argument with my b0ss and numerous angry users, I've added it anywayssss. Oh you people.

Now you may finally be able to use negative numbers and stuff.

Oh, and also postfix and prefix operations, which is kinda blazed :hotsprings: 

## Example: _(two heavy unit tests that passes)_
![image](https://user-images.githubusercontent.com/2477952/38214394-bfd5d6cc-36c4-11e8-9254-3e1356c5eb66.png)
